### PR TITLE
Fix QPainterPath compilation error

### DIFF
--- a/3rdparty/posterazor/paintcanvas.cpp
+++ b/3rdparty/posterazor/paintcanvas.cpp
@@ -23,6 +23,7 @@
 #include "paintcanvas.h"
 #include <QImage>
 #include <QPainter>
+#include <QPainterPath>
 
 PaintCanvas::PaintCanvas(QWidget *parent)
     : QWidget(parent)


### PR DESCRIPTION
Fixes the following compilation error:

```
g++ -c -pipe -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wall -Wextra -D_REENTRANT -fPIC -DHAS_EXPORTDIALOG -DHAS_WORDCLOUD_APPLIANCE -DHAS_LIKEBACK -DHAS_VIDEOCAPTURE -DHAS_TRANSLATIONS -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_PRINTSUPPORT_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_XML_LIB -DQT_CORE_LIB -I. -I. -I3rdparty/posterazor -I/usr/include/qt5 -I/usr/include/qt5/QtSvg -I/usr/include/qt5/QtPrintSupport -I/usr/include/qt5/QtOpenGL -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtXml -I/usr/include/qt5/QtCore -Ibuild -Ibuild -I/usr/lib64/qt5/mkspecs/linux-g++ -o build/posterazorcore.o 3rdparty/posterazor/posterazorcore.cpp
3rdparty/posterazor/paintcanvas.cpp: In member function 'virtual void PaintCanvas::drawOverlayText(const QPointF&, int, int, const QString&)':
3rdparty/posterazor/paintcanvas.cpp:89:22: error: aggregate 'QPainterPath textPath' has incomplete type and cannot be defined
   89 |         QPainterPath textPath;
      |                      ^~~~~~~~
make: *** [Makefile:2324: build/paintcanvas.o] Error 1
```